### PR TITLE
Update README for RSA PrivKey Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,7 @@ deployment to Heroku.
 Heroku Setup
 ------------
 
-
-|Deploy|
-
-.. |Deploy| image:: https://www.herokucdn.com/deploy/button.svg
-   :target: https://heroku.com/deploy?template=https://github.com/mariatta/github_app_boilerplate
-
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/mariatta/github_app_boilerplate)
 
 Add the following config vars in Heroku.
 
@@ -26,5 +21,4 @@ Add the following config vars in Heroku.
 -----BEGIN RSA PRIVATE KEY-----
 ...somereallylongtext...
 -----END RSA PRIVATE KEY-----
-
 ```

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,12 @@ deployment to Heroku.
 Heroku Setup
 ------------
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/mariatta/github_app_boilerplate)
+
+|Deploy|
+
+.. |Deploy| image:: https://www.herokucdn.com/deploy/button.svg
+   :target: https://heroku.com/deploy?template=https://github.com/mariatta/github_app_boilerplate
+
 
 Add the following config vars in Heroku.
 
@@ -17,8 +22,8 @@ Add the following config vars in Heroku.
 
 ``GH_PRIVATE_KEY``: The private key of your GitHub App. It looks like:
 
-```
------BEGIN RSA PRIVATE KEY-----
-...somereallylongtext...
------END RSA PRIVATE KEY-----
-```
+::
+
+  -----BEGIN RSA PRIVATE KEY-----
+  ...somereallylongtext...
+  -----END RSA PRIVATE KEY-----


### PR DESCRIPTION
Thank you so much for a great template repo for creating Github Apps!

The formatting in the README was not showing a nicely formatted Github Private Key. Changing the README to a markdown file solved this issue.